### PR TITLE
Improve input handling and fix special block crash

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,14 +46,17 @@
     <div class="player-container">
       <button class="player-toggle" id="togglePlayer1">1P オン/オフ</button>
       <canvas id="player1Canvas"></canvas>
+      <small>矢印キー: 移動 / Z: 回転 / X: フリップ / ↑: ハードドロップ</small>
     </div>
     <div class="player-container">
       <button class="player-toggle" id="togglePlayer2">2P オン/オフ</button>
       <canvas id="player2Canvas"></canvas>
+      <small>A,D,S: 移動 / W: 回転 / E: フリップ / Q: ハードドロップ</small>
     </div>
     <div class="player-container">
       <button class="player-toggle" id="togglePlayer3">3P オン/オフ</button>
       <canvas id="player3Canvas"></canvas>
+      <small>J,L,K: 移動 / I: 回転 / O: フリップ / U: ハードドロップ</small>
     </div>
   </div>
   <script src="tetris.js"></script>


### PR DESCRIPTION
## Summary
- prevent crash when placing blocks by removing duplicate special block call
- unify input timing with `INPUT_INTERVAL` constant and add keyboard support
- display keyboard controls for each player

## Testing
- `node --check tetris.js`

------
https://chatgpt.com/codex/tasks/task_e_6856665d2a48832b9ee0be86fb6cb24f