### PR TITLE
Implement obstacle attack and flip action

### DIFF
--- a/index.html
+++ b/index.html
@@ -565,10 +565,11 @@
                   gameInstances.forEach(currentGame => {
                       if (currentGame.gameOver) return;
                       const clearedLines = currentGame.update(time);
-                      if (clearedLines > 0) {
+                      if (clearedLines >= 2) {
                           gameInstances.forEach(otherPlayer => {
                               if (otherPlayer !== currentGame && !otherPlayer.gameOver) {
-                                  otherPlayer.addObstacle(clearedLines);
+                                  const attackLines = clearedLines >= 4 ? 3 : 1;
+                                  otherPlayer.addObstacle(attackLines);
                               }
                           });
                       }
@@ -586,9 +587,12 @@
             const handleHardDrop = (player) => {
                 if (!player) return;
                 const clearedLines = player.hardDrop();
-                if (clearedLines > 0) {
+                if (clearedLines >= 2) {
                     gameInstances.forEach(p => {
-                        if (p !== player && !p.gameOver) p.addObstacle(clearedLines);
+                        if (p !== player && !p.gameOver) {
+                            const attackLines = clearedLines >= 4 ? 3 : 1;
+                            p.addObstacle(attackLines);
+                        }
                     });
                 }
             };
@@ -598,8 +602,9 @@
                 if (event.code === 'ArrowLeft') p1.move(-1);
                 else if (event.code === 'ArrowRight') p1.move(1);
                 else if (event.code === 'ArrowDown') p1.drop();
-                else if (event.code === 'KeyZ' || event.code === 'KeyX') p1.rotate();
+                else if (event.code === 'KeyZ') p1.rotate();
                 else if (event.code === 'ArrowUp') handleHardDrop(p1);
+                else if (event.code === 'KeyX') p1.flip();
             }
 
             const p2 = humanPlayers.find(g => g.playerId === 2);
@@ -607,8 +612,9 @@
                 if (event.code === 'KeyA') p2.move(-1);
                 else if (event.code === 'KeyD') p2.move(1);
                 else if (event.code === 'KeyS') p2.drop();
-                else if (event.code === 'KeyE') p2.rotate();
+                else if (event.code === 'KeyQ') p2.rotate();
                 else if (event.code === 'KeyW') handleHardDrop(p2);
+                else if (event.code === 'KeyE') p2.flip();
             }
             
             const p3 = humanPlayers.find(g => g.playerId === 3);
@@ -616,8 +622,9 @@
                 if (event.code === 'KeyJ') p3.move(-1);
                 else if (event.code === 'KeyL') p3.move(1);
                 else if (event.code === 'KeyK') p3.drop();
-                else if (event.code === 'KeyO') p3.rotate();
+                else if (event.code === 'KeyP') p3.rotate();
                 else if (event.code === 'KeyI') handleHardDrop(p3);
+                else if (event.code === 'KeyO') p3.flip();
             }
         });
     });

--- a/tetris.js
+++ b/tetris.js
@@ -4,6 +4,11 @@ const boardWidth = 10;
 const boardHeight = 20;
 const INPUT_INTERVAL = 180; // 入力の最小間隔(ms)
 
+// ブロックカラー定義
+const COLORS = {
+    OBSTACLE: '#808080'
+};
+
 // 汎用コントローラー用ボタンマッピングシステム
 class UniversalGamepadMapper {
     constructor() {
@@ -478,6 +483,16 @@ class Tetris {
         }
     }
 
+    flip() {
+        if (this.gameOver || !this.currentShape) return;
+
+        const flippedShape = this.currentShape.shape.map(row => row.slice().reverse());
+        if (this.isValidMove(flippedShape, this.currentPosition.x, this.currentPosition.y)) {
+            this.currentShape.shape = flippedShape;
+            this.updateGhostPosition();
+        }
+    }
+
     hardDrop() {
         let clearedLines = 0;
         while (this.canMove(0, 1)) {
@@ -651,11 +666,11 @@ class Tetris {
     }
 
     addObstacle(lines) {
-        if (lines <= 0) return;
+        if (this.gameOver || lines <= 0) return;
         
         // アニメーション付きでお邪魔ブロックを追加
         for (let i = 0; i < lines; i++) {
-            const obstacleRow = Array(boardWidth).fill('#808080');
+            const obstacleRow = Array(boardWidth).fill(COLORS.OBSTACLE);
             obstacleRow[Math.floor(Math.random() * boardWidth)] = 0; // ランダムな位置に穴を開ける
             
             // アニメーション情報を追加
@@ -670,6 +685,11 @@ class Tetris {
         // ボードから上の行を削除
         for (let i = 0; i < lines; i++) {
             this.board.splice(0, 1);
+        }
+
+        // 現在のピースが衝突する場合はゲームオーバー
+        if (this.currentShape && !this.isValidMove(this.currentShape.shape, this.currentPosition.x, this.currentPosition.y)) {
+            this.gameOver = true;
         }
     }
     


### PR DESCRIPTION
## Summary
- add color constants for obstacle blocks
- implement `flip` method
- trigger obstacle line attacks only when clearing 2+ lines
- add keyboard bindings for flip and update rotate keys

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68568ba7bed8832ba756aad5b39b4874