### PR TITLE
Improve main startup error handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,9 +2,17 @@
 Main entry point for the Tetris game.
 """
 
-import pygame
 import sys
 import os
+
+try:
+    import pygame
+except ModuleNotFoundError:
+    print("Error: pygame is not installed.")
+    print("Please run 'pip install -r requirements.txt' to install dependencies.")
+    print("Alternatively, launch the game via 'run_game.sh' or 'run_game.bat'.")
+    sys.exit(1)
+
 from constants import *
 from game_manager import GameManager
 from font_manager import cleanup_fonts


### PR DESCRIPTION
## Summary
- gracefully handle missing `pygame` dependency
- recommend installing requirements or using platform launch scripts

## Testing
- `uv run python test_startup.py`
- `uv run python test_game_with_fonts.py`
- `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python main.py`

------
https://chatgpt.com/codex/tasks/task_e_68572e32cafc832b8a1f5210efa0c18f