### PR TITLE
Improve event polling

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -5,8 +5,17 @@ Utility functions for the Tetris game.
 import pygame
 
 def safe_events():
-    """Safely call ``pygame.event.get()`` and return an empty list on failure."""
+    """Safely retrieve pending pygame events.
+
+    Some environments occasionally raise errors when calling
+    ``pygame.event.get`` directly, which can spam the console and halt
+    input processing.  This helper pumps the event queue first and
+    gracefully returns an empty list if any exception is raised.
+    """
+
     try:
+        # Ensure SDL processes internal actions before fetching events.
+        pygame.event.pump()
         return pygame.event.get()
     except Exception as e:
         print(f"[WARN] Event polling error: {e}")


### PR DESCRIPTION
## Summary
- make safe_events pump the event queue before retrieving events
- expand safe_events docstring

## Testing
- `pytest test_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6857de6a1ad0832bb19870b9f046a983